### PR TITLE
Fix missing invite tracking

### DIFF
--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -29,6 +29,11 @@ module.exports = {
       inviterId = usedInvite?.inviter?.id;
     }
 
+    // Save inviter mapping for commands like /inviter and /invited
+    if (inviterId) {
+      client.invitedByMap.set(member.id, inviterId);
+    }
+
     // --- 2) Cộng XP nếu có inviter ---
     if (inviterId) {
       const amount = xpCfg.inviteXP;


### PR DESCRIPTION
## Summary
- keep track of who invited new members so `/inviter` and `/invited` work

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6842a5b8b388832e92807a4a2847c7eb